### PR TITLE
Remove web+mastodon protocol

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -20,9 +20,6 @@
       }
     }
   },
-  "optionsMastodonInstanceUrlNote": {
-    "message": "If the browser is registered to handle the \"web+mastodon:\" protocol, leave the Instance URL input field empty. To check whether it is registered, refer to \"Applications\" section from \"about:preferences\"."
-  },
   "optionsLabel": {
     "message": "Options"
   },

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -20,9 +20,6 @@
       }
     }
   },
-  "optionsMastodonInstanceUrlNote": {
-    "message": "ブラウザに \"web+mastodon:\" プロトコルへの関連付けが登録済みの場合、インスタンス URL の入力フィールドは空のままで構いません。関連付けが登録されているかどうかを確認するには、 \"about:preferences\" の \"プログラム\" の項目を参照してください。"
-  },
   "optionsLabel": {
     "message": "設定"
   },

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -20,9 +20,6 @@
       }
     }
   },
-  "optionsMastodonInstanceUrlNote": {
-    "message": "如果浏览器已注册了 web+mastodon: 协议的处理程序，请将 Instance URL 框留空。要检查它是否已注册，在 about:preferences - “应用程序”中检查。"
-  },
   "optionsLabel": {
     "message": "选项"
   },

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -113,10 +113,6 @@
                 <p data-i18n="optionsEnableSnsDetail,Mastodon">
                   Enable sharing with Mastodon.
                 </p>
-                <p data-i18n="optionsMastodonInstanceUrlNote">
-                  If the browser is registered to handle the "web+mastodon:" protocol, leave the Instance URL input field empty.
-                  To check whether it is registered, refer to "Applications" section from "about:preferences".
-                </p>
               </div>
             </details>
           </div>

--- a/src/mjs/main.js
+++ b/src/mjs/main.js
@@ -170,7 +170,6 @@ export const extractClickedData = async (info = {}, tab = {}) => {
         shareText = encodeURIComponent(selText || tabTitle);
         shareUrl = encodeURIComponent(!tabUrlHash && canonicalUrl || tabUrl);
       }
-      url = tmpl.replace("%url%", shareUrl).replace("%text%", shareText);
       if (subItem) {
         const items = Object.values(subItem);
         let itemInfo;
@@ -181,10 +180,12 @@ export const extractClickedData = async (info = {}, tab = {}) => {
           }
         }
         if (itemInfo) {
-          url = await createSnsUrl(url, itemInfo);
+          url = await createSnsUrl(shareUrl, itemInfo);
         }
+      } else {
+        url = tmpl.replace("%url%", shareUrl).replace("%text%", shareText);
       }
-      func.push(createTab({
+      url && func.push(createTab({
         url, windowId,
         active: true,
         index: tabIndex + 1,

--- a/src/mjs/sns.js
+++ b/src/mjs/sns.js
@@ -26,7 +26,7 @@ export default {
   Mastodon: {
     id: "Mastodon",
     menu: "&Mastodon",
-    url: "web+mastodon://share?text=%text%+%url%",
+    url: null,
     subItem: {
       mastodonInstanceUrl: {
         url: "%origin%/intent?uri=%query%",

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -357,7 +357,7 @@ describe("main", () => {
 
     it("should get array", async () => {
       mjs.sns.set("foo", {
-        url: "https://example.com?u=%url%&amp;t=%text%",
+        url: null,
         subItem: {
           bar: {
             url: "%origin%/?q=%query%",


### PR DESCRIPTION
`web+mastodon` protocol got removed.
Ref [Release v2.5.0 · tootsuite/mastodon](https://github.com/tootsuite/mastodon/releases/tag/v2.5.0)
